### PR TITLE
refactor: use react-addons-test-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ const rendered = shallowRender(<div className="test" />);
 assert.equal(rendered.type, 'div');
 assert.equal(rendered.props.className, 'test');
 ```
+
+Please note that as of React 0.14, [shallow rendering won't render
+primitives](https://github.com/facebook/react/issues/4721).
+[The good thing is that you don't need it](https://github.com/facebook/react/issues/4721#issuecomment-135923690)
+as you can just do:
+
+```
+var el = React.createElement('h1', {}, 'Hello');
+console.log(el);
+```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "James Friend <james@jsdf.co> (http://jsdf.co/)",
   "license": "MIT",
   "dependencies": {
-    "react": "^0.13.3"
+    "react-addons-test-utils": "^0.14.0"
   },
   "devDependencies": {
     "tap": "^1.4.1"

--- a/shallowRender.js
+++ b/shallowRender.js
@@ -1,7 +1,7 @@
-var React = require('react/addons');
+var TestUtils = require('react-addons-test-utils');
 
 function shallowRender(element) {
-  var shallowRenderer = React.addons.TestUtils.createRenderer();
+  var shallowRenderer = TestUtils.createRenderer();
   shallowRenderer.render(element);
   return shallowRenderer.getRenderOutput();
 }

--- a/test/shallowRender.js
+++ b/test/shallowRender.js
@@ -2,9 +2,17 @@ var tap = require('tap');
 var React = require('react');
 var shallowRender = require('../');
 
+var type = 'div';
+var props = {className: 'test'};
+function Test(props) {
+  return React.createElement(type, props);
+}
+
 tap.test('it works', function (t) {
-  var type = 'div';
-  var props = {className: 'test'};
-  t.similar(shallowRender(React.createElement(type, props)), {type: type, props: props});
+  var $component = shallowRender(React.createElement(Test, props));
+
+  t.equals($component.type, type, 'matches the type');
+  t.deepEquals($component.props, props, 'matches the props');
+
   t.end();
 });


### PR DESCRIPTION
React 0.14 deprecated `react/addons` in favour of a more modular approach.
`TestUtils` was turned into `react-addons-test-utils`. This commit uses
that package instead.
